### PR TITLE
Remove community flag from version string

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,5 @@ go-licenses save . ^
     --ignore github.com/libsql/sqlite-antlr4-parser
 
 go install -v ^
-    -ldflags "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.flavor=community' -X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v%PKG_VERSION%'" ^
+    -ldflags "-X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v%PKG_VERSION%'" ^
     .
-    

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,5 +12,5 @@ go-licenses save . \
     --ignore github.com/libsql/sqlite-antlr4-parser
 
 go build -v \
-    -ldflags "-s -w -X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.flavor=community' -X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v$PKG_VERSION'" \
+    -ldflags "-s -w -X 'ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v$PKG_VERSION'" \
     -o $PREFIX/bin/atlas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Until the `atlas` SDK supports correctly parsing the `community` flag from the version string (cf. https://github.com/ariga/atlas-go-sdk/pull/66), this allows this feedstock's build to be used with the Atlas Terraform provider. This change does not change the license of the binary, it only emits inaccurate metadata as an intermediate fix.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
